### PR TITLE
add support for laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "LaravelPlanetscale"
     ],
     "require": {
-        "illuminate/support": "~9|~10|~11"
+        "illuminate/support": "~9|~10|~11|~12"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.0",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Laravel 12 support by allowing illuminate/support ~12 in composer.json. This enables install and use on Laravel 12 without code changes.

<!-- End of auto-generated description by cubic. -->

