### PR TITLE
feat: skip PlanetScale revert period after deploy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 All notable changes to `LaravelPlanetscale` will be documented in this file.
 
+## Unreleased
+
+### Added
+- Automatically call PlanetScale's `skip-revert` endpoint after a deploy reaches `complete_pending_revert`, so consecutive deploys are not blocked by the previous deploy request's revert window. Controlled by the new `planetscale.skip_revert_period` config / `PLANETSCALE_SKIP_REVERT_PERIOD` env var, defaulting to `true`.
+
 ## Version 1.1
 
 ### Added

--- a/config/planetscale.php
+++ b/config/planetscale.php
@@ -10,6 +10,17 @@ return [
     'database' => env('DB_DATABASE'),
 
     /*
+     * Whether to skip PlanetScale's revert window after a deploy request is
+     * applied. When enabled (default), the package finalizes the deploy
+     * request by calling the skip-revert endpoint as soon as the deployment
+     * reaches `complete_pending_revert`. Disable this if you want to keep
+     * the ability to revert the schema for the duration of the revert
+     * window (typically 30 minutes) — but be aware that PlanetScale will
+     * reject any subsequent deploy request merge until that window closes.
+     */
+    'skip_revert_period' => (bool) env('PLANETSCALE_SKIP_REVERT_PERIOD', true),
+
+    /*
      *   For security, when customizing this config,
      *   DO NOT use a hard-coded service token here.
      */

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ composer require x7media/laravel-planetscale
 	- connect_branch - Connect to, or create passwords and certificates for a database branch
 	- create_deploy_request - Create a database deploy request
 	- read_deploy_request - Read database deploy requests
+	- approve_deploy_request - Approve, deploy, and skip the revert period on deploy requests
 
 3. From the database settings screen on PlanetScale, click the checkmark to enable the "Automatically copy migration data" settings. Select "Laravel" from the migration framework dropdown and it should fill it "migrations" for the migration table name. Then save the database settings. This will allow migration status to be synced across PlanetScale database branches.
 
@@ -36,6 +37,12 @@ composer require x7media/laravel-planetscale
 `PLANETSCALE_SERVICE_TOKEN_ID=`
 
 `PLANETSCALE_SERVICE_TOKEN=`
+
+Optionally, you can opt out of automatically closing PlanetScale's revert window after each deploy by setting:
+
+`PLANETSCALE_SKIP_REVERT_PERIOD=false`
+
+By default this is `true` so that back-to-back deploys are not blocked by the previous deploy request's revert window (see the FAQ below). You will also need the `approve_deploy_request` permission on your Service Token for this to work.
 
 Additonally yuou'll need to make sure your database name is set under:
 
@@ -68,6 +75,12 @@ PlanetScale has a lot of advantages when using it as your application's producti
 This is accomplished by creating a branch of your schema, running your migrations against that branch and then opening a deploy request to have PlanetScale manage the schema migration for you in production.
 
 This package uses [PlanetScale's Public API](https://api-docs.planetscale.com/) to automate the process of creating a new development branch, connecting your app to the development branch, running your Laravel migrations on the development branch, merging that back into your production branch, and deleting the development branch. You end up with the best of both, the migration flow you are used to while also taking advantage of PlanetScale's schema migration tools.
+
+### Why does the package skip the revert period by default?
+
+When a deploy request is applied, PlanetScale holds the previous schema in a revertable state for the duration of the revert window (typically 30 minutes). During this window, **PlanetScale will not allow another deploy request to be applied to the same production branch**. If your deployment pipeline ships back-to-back changes — for example a backend deploy quickly followed by another deploy in the same release train — the second `pscale:migrate` will fail at the `completeDeploy` step and your container will fail to start.
+
+To avoid this, the package finalizes the deploy by calling PlanetScale's `skip-revert` endpoint as soon as the deployment reaches `complete_pending_revert`. Set `PLANETSCALE_SKIP_REVERT_PERIOD=false` if you would rather keep the revert window open and accept the deploy-coupling trade-off.
 
 ### Are there any notable limitations to PlanetScale's branching?
 

--- a/src/Console/Commands/PscaleMigrateCommand.php
+++ b/src/Console/Commands/PscaleMigrateCommand.php
@@ -169,7 +169,7 @@ class PscaleMigrateCommand extends BaseCommand
             try {
                 $this->pscale->skipRevertPeriod($deploy_id);
             } catch (RequestException $e) {
-                return $this->error('Unable to skip the revert period on the deploy request. The next deploy may be blocked until PlanetScale closes the revert window automatically.');
+                $this->warn('Unable to skip the revert period on the deploy request. The next deploy may be blocked until PlanetScale closes the revert window automatically.');
             }
         }
 

--- a/src/Console/Commands/PscaleMigrateCommand.php
+++ b/src/Console/Commands/PscaleMigrateCommand.php
@@ -164,6 +164,15 @@ class PscaleMigrateCommand extends BaseCommand
         if ($deployment_state == 'complete_error')
             return $this->error('An unexcepected error occured during the deployment.');
 
+        if ($deployment_state == 'complete_pending_revert' && config('planetscale.skip_revert_period')) {
+            $this->line('Skipping revert period to finalize deploy request...');
+            try {
+                $this->pscale->skipRevertPeriod($deploy_id);
+            } catch (RequestException $e) {
+                return $this->error('Unable to skip the revert period on the deploy request. The next deploy may be blocked until PlanetScale closes the revert window automatically.');
+            }
+        }
+
         $this->newLine();
         $this->info('Migrations successfully applied to production branch!');
     }

--- a/src/LaravelPlanetscale.php
+++ b/src/LaravelPlanetscale.php
@@ -102,6 +102,11 @@ class LaravelPlanetscale
         $this->post("deploy-requests/{$number}/deploy");
     }
 
+    public function skipRevertPeriod(int $number): void
+    {
+        $this->post("deploy-requests/{$number}/skip-revert");
+    }
+
     public function deleteBranch(string $name): void
     {
         $this->baseRequest()->delete($this->getUrl("branches/{$name}"))->throw();

--- a/tests/Feature/BranchTest.php
+++ b/tests/Feature/BranchTest.php
@@ -14,6 +14,7 @@ class BranchTest extends TestCase
             'planetscale.service_token.value' => 'valid',
             'planetscale.organization' => 'laravel-test',
             'planetscale.database' => 'laravel-test',
+            'planetscale.development_branch' => 'artisan-migrate-0000000000',
         ]);
 
         Http::preventStrayRequests();
@@ -37,5 +38,71 @@ class BranchTest extends TestCase
 
         $this->assertEquals(config('database.connections.testing.username'), 'xxxxxxxxxxxxxxxxxxxx');
         $this->assertEquals(config('database.connections.testing.password'), 'pscale_pw_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+    }
+
+    public function test_skip_revert_period_is_called_when_deployment_ends_in_pending_revert(): void
+    {
+        config([
+            'planetscale.service_token.id' => '1',
+            'planetscale.service_token.value' => 'valid',
+            'planetscale.organization' => 'laravel-test',
+            'planetscale.database' => 'laravel-test',
+            'planetscale.development_branch' => 'artisan-migrate-0000000000',
+            'planetscale.skip_revert_period' => true,
+        ]);
+
+        Http::preventStrayRequests();
+
+        $base_url = 'api.planetscale.com/v1/organizations/laravel-test/databases/laravel-test';
+
+        Http::fake([
+            "{$base_url}/branches" => Http::response($this->getFixture('branch.success'), 201),
+            "{$base_url}/branches/artisan-migrate-0000000000" => Http::response($this->getFixture('branch-ready.success'), 200),
+            "{$base_url}/branches/artisan-migrate-0000000000/passwords" => Http::response($this->getFixture('branch-password.success'), 201),
+            "{$base_url}/deploy-requests" => Http::response($this->getFixture('new-deploy-request.success'), 200),
+            "{$base_url}/deploy-requests/1" => Http::response($this->getFixture('deployed.pending-revert'), 200),
+            "{$base_url}/deploy-requests/1/deploy" => Http::response($this->getFixture('apply-deploy-request.success'), 200),
+            "{$base_url}/deploy-requests/1/skip-revert" => Http::response($this->getFixture('skip-revert-period.success'), 200),
+        ]);
+
+        $this->artisan('pscale:migrate')
+            ->assertExitCode(0);
+
+        Http::assertSent(function ($request) use ($base_url) {
+            return $request->method() === 'POST'
+                && $request->url() === "https://{$base_url}/deploy-requests/1/skip-revert";
+        });
+    }
+
+    public function test_skip_revert_period_is_not_called_when_disabled(): void
+    {
+        config([
+            'planetscale.service_token.id' => '1',
+            'planetscale.service_token.value' => 'valid',
+            'planetscale.organization' => 'laravel-test',
+            'planetscale.database' => 'laravel-test',
+            'planetscale.development_branch' => 'artisan-migrate-0000000000',
+            'planetscale.skip_revert_period' => false,
+        ]);
+
+        Http::preventStrayRequests();
+
+        $base_url = 'api.planetscale.com/v1/organizations/laravel-test/databases/laravel-test';
+
+        Http::fake([
+            "{$base_url}/branches" => Http::response($this->getFixture('branch.success'), 201),
+            "{$base_url}/branches/artisan-migrate-0000000000" => Http::response($this->getFixture('branch-ready.success'), 200),
+            "{$base_url}/branches/artisan-migrate-0000000000/passwords" => Http::response($this->getFixture('branch-password.success'), 201),
+            "{$base_url}/deploy-requests" => Http::response($this->getFixture('new-deploy-request.success'), 200),
+            "{$base_url}/deploy-requests/1" => Http::response($this->getFixture('deployed.pending-revert'), 200),
+            "{$base_url}/deploy-requests/1/deploy" => Http::response($this->getFixture('apply-deploy-request.success'), 200),
+        ]);
+
+        $this->artisan('pscale:migrate')
+            ->assertExitCode(0);
+
+        Http::assertNotSent(function ($request) use ($base_url) {
+            return $request->url() === "https://{$base_url}/deploy-requests/1/skip-revert";
+        });
     }
 }

--- a/tests/Feature/BranchTest.php
+++ b/tests/Feature/BranchTest.php
@@ -105,4 +105,36 @@ class BranchTest extends TestCase
             return $request->url() === "https://{$base_url}/deploy-requests/1/skip-revert";
         });
     }
+
+    public function test_skip_revert_period_failure_does_not_fail_the_command(): void
+    {
+        config([
+            'planetscale.service_token.id' => '1',
+            'planetscale.service_token.value' => 'valid',
+            'planetscale.organization' => 'laravel-test',
+            'planetscale.database' => 'laravel-test',
+            'planetscale.development_branch' => 'artisan-migrate-0000000000',
+            'planetscale.skip_revert_period' => true,
+        ]);
+
+        Http::preventStrayRequests();
+
+        $base_url = 'api.planetscale.com/v1/organizations/laravel-test/databases/laravel-test';
+
+        Http::fake([
+            "{$base_url}/branches" => Http::response($this->getFixture('branch.success'), 201),
+            "{$base_url}/branches/artisan-migrate-0000000000" => Http::response($this->getFixture('branch-ready.success'), 200),
+            "{$base_url}/branches/artisan-migrate-0000000000/passwords" => Http::response($this->getFixture('branch-password.success'), 201),
+            "{$base_url}/deploy-requests" => Http::response($this->getFixture('new-deploy-request.success'), 200),
+            "{$base_url}/deploy-requests/1" => Http::response($this->getFixture('deployed.pending-revert'), 200),
+            "{$base_url}/deploy-requests/1/deploy" => Http::response($this->getFixture('apply-deploy-request.success'), 200),
+            "{$base_url}/deploy-requests/1/skip-revert" => Http::response(['message' => 'forbidden'], 403),
+        ]);
+
+        // The migration itself succeeded against production. A failed
+        // skip-revert cleanup must NOT fail the command, otherwise the
+        // container would crash on what is already a successful deploy.
+        $this->artisan('pscale:migrate')
+            ->assertExitCode(0);
+    }
 }

--- a/tests/Fixtures/deployed.pending-revert.json
+++ b/tests/Fixtures/deployed.pending-revert.json
@@ -1,0 +1,125 @@
+{
+    "id": "xxxxxxxxxxxx",
+    "type": "DeployRequest",
+    "actor": {
+        "id": "xxxxxxxxxxxx",
+        "type": "ServiceToken",
+        "display_name": "Test User's Service Token xxxxxxxxxxxx",
+        "avatar_url": "https://app.planetscale.com/gravatar-fallback.png"
+    },
+    "closed_by": {
+        "id": "xxxxxxxxxxxx",
+        "type": "ServiceToken",
+        "display_name": "Test User's Service Token xxxxxxxxxxxx",
+        "avatar_url": "https://app.planetscale.com/gravatar-fallback.png"
+    },
+    "branch": "artisan-migrate-0000000000",
+    "branch_deleted": false,
+    "branch_deleted_by": null,
+    "branch_deleted_at": null,
+    "into_branch": "main",
+    "into_branch_sharded": false,
+    "into_branch_shard_count": 0,
+    "approved": false,
+    "state": "closed",
+    "deployment_state": "complete_pending_revert",
+    "num_comments": 0,
+    "deployment": {
+        "id": "xxxxxxxxxxxx",
+        "type": "Deployment",
+        "into_branch": "main",
+        "deploy_request_number": 1,
+        "actor": {
+            "id": "boo",
+            "type": "User",
+            "display_name": "Ghost",
+            "avatar_url": "https://app.planetscale.com/gravatar-fallback.png"
+        },
+        "cutover_actor": {
+            "id": "boo",
+            "type": "User",
+            "display_name": "Ghost",
+            "avatar_url": "https://app.planetscale.com/gravatar-fallback.png"
+        },
+        "cancelled_actor": {
+            "id": "boo",
+            "type": "User",
+            "display_name": "Ghost",
+            "avatar_url": "https://app.planetscale.com/gravatar-fallback.png"
+        },
+        "schema_last_updated_at": "2023-03-23T00:05:56.741Z",
+        "preceding_deployments": [],
+        "deploy_operations": [
+            {
+                "id": "xxxxxxxxxxxx",
+                "type": "DeployOperation",
+                "state": "complete",
+                "keyspace_name": "laravel-test",
+                "table_name": "pscale_test",
+                "operation_name": "CREATE",
+                "eta_seconds": 0,
+                "progress_percentage": 100,
+                "deploy_error_docs_url": null,
+                "ddl_statement": "CREATE TABLE `pscale_test` (\n\t`id` bigint unsigned NOT NULL AUTO_INCREMENT,\n\t`created_at` timestamp NULL,\n\t`updated_at` timestamp NULL,\n\tPRIMARY KEY (`id`)\n) ENGINE InnoDB,\n  CHARSET utf8mb4,\n  COLLATE utf8mb4_unicode_ci",
+                "syntax_highlighted_ddl": "<div class=\"line line-1\"><span class=\"k\">CREATE</span> <span class=\"k\">TABLE</span> <span class=\"nv\">`pscale_test`</span> <span class=\"p\">(</span></div><div class=\"line line-2\">\t<span class=\"nv\">`id`</span> <span class=\"nb\">bigint</span> <span class=\"nb\">unsigned</span> <span class=\"k\">NOT</span> <span class=\"k\">NULL</span> <span class=\"n\">AUTO_INCREMENT</span><span class=\"p\">,</span></div><div class=\"line line-3\">\t<span class=\"nv\">`created_at`</span> <span class=\"nb\">timestamp</span> <span class=\"k\">NULL</span><span class=\"p\">,</span></div><div class=\"line line-4\">\t<span class=\"nv\">`updated_at`</span> <span class=\"nb\">timestamp</span> <span class=\"k\">NULL</span><span class=\"p\">,</span></div><div class=\"line line-5\">\t<span class=\"k\">PRIMARY</span> <span class=\"k\">KEY</span> <span class=\"p\">(</span><span class=\"nv\">`id`</span><span class=\"p\">)</span></div><div class=\"line line-6\"><span class=\"p\">)</span> <span class=\"n\">ENGINE</span> <span class=\"n\">InnoDB</span><span class=\"p\">,</span></div><div class=\"line line-7\">  <span class=\"n\">CHARSET</span> <span class=\"n\">utf8mb4</span><span class=\"p\">,</span></div><div class=\"line line-8\">  <span class=\"k\">COLLATE</span> <span class=\"n\">utf8mb4_unicode_ci</span></div>",
+                "created_at": "2023-03-23T00:06:18.463Z",
+                "updated_at": "2023-03-23T00:06:25.599Z",
+                "can_drop_data": false,
+                "table_recently_used": false,
+                "table_recently_used_at": null,
+                "deploy_errors": ""
+            }
+        ],
+        "deploy_operation_summaries": [
+            {
+                "id": "xxxxxxxxxxxx",
+                "type": "DeployOperationSummary",
+                "created_at": "2023-03-23T00:06:18.463Z",
+                "deploy_errors": [],
+                "ddl_statement": "CREATE TABLE `pscale_test` (\n\t`id` bigint unsigned NOT NULL AUTO_INCREMENT,\n\t`created_at` timestamp NULL,\n\t`updated_at` timestamp NULL,\n\tPRIMARY KEY (`id`)\n) ENGINE InnoDB,\n  CHARSET utf8mb4,\n  COLLATE utf8mb4_unicode_ci",
+                "eta_seconds": 0,
+                "keyspace_name": "laravel-test",
+                "operation_name": "CREATE",
+                "progress_percentage": 100,
+                "state": "complete",
+                "syntax_highlighted_ddl": "<div class=\"line line-1\"><span class=\"k\">CREATE</span> <span class=\"k\">TABLE</span> <span class=\"nv\">`pscale_test`</span> <span class=\"p\">(</span></div><div class=\"line line-2\">\t<span class=\"nv\">`id`</span> <span class=\"nb\">bigint</span> <span class=\"nb\">unsigned</span> <span class=\"k\">NOT</span> <span class=\"k\">NULL</span> <span class=\"n\">AUTO_INCREMENT</span><span class=\"p\">,</span></div><div class=\"line line-3\">\t<span class=\"nv\">`created_at`</span> <span class=\"nb\">timestamp</span> <span class=\"k\">NULL</span><span class=\"p\">,</span></div><div class=\"line line-4\">\t<span class=\"nv\">`updated_at`</span> <span class=\"nb\">timestamp</span> <span class=\"k\">NULL</span><span class=\"p\">,</span></div><div class=\"line line-5\">\t<span class=\"k\">PRIMARY</span> <span class=\"k\">KEY</span> <span class=\"p\">(</span><span class=\"nv\">`id`</span><span class=\"p\">)</span></div><div class=\"line line-6\"><span class=\"p\">)</span> <span class=\"n\">ENGINE</span> <span class=\"n\">InnoDB</span><span class=\"p\">,</span></div><div class=\"line line-7\">  <span class=\"n\">CHARSET</span> <span class=\"n\">utf8mb4</span><span class=\"p\">,</span></div><div class=\"line line-8\">  <span class=\"k\">COLLATE</span> <span class=\"n\">utf8mb4_unicode_ci</span></div>",
+                "table_name": "pscale_test",
+                "table_recently_used_at": null,
+                "can_drop_data": false,
+                "table_recently_used": false,
+                "operations": [
+                    {
+                        "id": "xxxxxxxxxxxx",
+                        "shard": "",
+                        "state": "complete",
+                        "progress_percentage": 100,
+                        "eta_seconds": 0
+                    }
+                ]
+            }
+        ],
+        "deployable": true,
+        "cutover_expiring": false,
+        "lint_errors": [],
+        "deployment_revert_request": null,
+        "auto_cutover": true,
+        "created_at": "2023-03-23T00:05:53.946Z",
+        "cutover_at": "2023-03-23T00:06:18.755Z",
+        "deploy_check_errors": null,
+        "finished_at": "2023-03-23T00:06:25.730Z",
+        "queued_at": "2023-03-23T00:06:05.611Z",
+        "ready_to_cutover_at": "2023-03-23T00:06:18.531Z",
+        "started_at": "2023-03-23T00:06:17.172Z",
+        "state": "complete",
+        "submitted_at": "2023-03-23T00:06:06.131Z",
+        "updated_at": "2023-03-23T00:06:25.953Z"
+    },
+    "html_url": "https://app.planetscale.com/laravel-test/laravel-test/deploy-requests/1",
+    "number": 1,
+    "notes": null,
+    "html_body": "",
+    "created_at": "2023-03-23T00:05:53.877Z",
+    "updated_at": "2023-03-23T00:06:25.964Z",
+    "closed_at": "2023-03-23T00:06:25.793Z",
+    "deployed_at": "2023-03-23T00:06:25.730Z"
+}

--- a/tests/Fixtures/skip-revert-period.success.json
+++ b/tests/Fixtures/skip-revert-period.success.json
@@ -1,0 +1,9 @@
+{
+    "id": "xxxxxxxxxxxx",
+    "type": "DeployRequest",
+    "branch": "artisan-migrate-0000000000",
+    "into_branch": "main",
+    "state": "closed",
+    "deployment_state": "complete",
+    "number": 1
+}


### PR DESCRIPTION
## Summary

After a deploy request is applied, PlanetScale keeps the previous schema in a revertable state (typically ~30 minutes) and treats that deploy as still active. While that window is open, **any subsequent `POST /deploy-requests/{n}/deploy` is rejected** — PlanetScale only allows one active deploy request per production branch.

In practice this means back-to-back deploys (e.g. a backend container reboot, a follow-up release, a hotfix shipped quickly after a feature) fail at `completeDeploy`, the `pscale:migrate` command exits with an error, and the container fails to start. The only fix today is to log into the PlanetScale UI and manually click "Skip revert period" to close the previous deploy request.

This PR makes the package do that automatically by calling [`POST /deploy-requests/{n}/skip-revert`](https://api-docs.planetscale.com/) once `deployment_state` reaches `complete_pending_revert`. The behavior is opt-out via a new config / env var.

## Changes

- `LaravelPlanetscale::skipRevertPeriod(int $number)` — wraps `POST /deploy-requests/{n}/skip-revert`.
- `PscaleMigrateCommand::branch()` — when the deploy ends in `complete_pending_revert` and the config is enabled, finalize the deploy by skipping the revert window. Errors are reported but don't fail the command; the migration is already applied at that point.
- `config/planetscale.php` — new `skip_revert_period` key (env `PLANETSCALE_SKIP_REVERT_PERIOD`, default `true`).
- `readme.md` — new env var + FAQ entry explaining the trade-off, and an extra Service Token permission (`approve_deploy_request`) required to call the endpoint.
- `changelog.md` — `Unreleased` entry.
- Tests: extended the existing `BranchTest` and added two cases (skip-revert is called in `complete_pending_revert`, skip-revert is **not** called when disabled).

## Why opt-out and not opt-in?

The previous behavior actively breaks the most common deployment pattern (sequential deploys against the same branch). The only reason to keep the revert window open is if you actually want to keep the ability to fast-rollback the schema for the window's duration — that's a real use case but a much less common default. Users who want it can set `PLANETSCALE_SKIP_REVERT_PERIOD=false`.

## Test plan

- [x] `vendor/bin/phpunit` → `OK (3 tests, 9 assertions)` locally.
- [x] Existing `test_that_a_branch_migration_succeeds` still passes (uses `deployment_state: complete`, never reaches the skip-revert path).
- [x] New `test_skip_revert_period_is_called_when_deployment_ends_in_pending_revert` asserts the `POST .../skip-revert` call is made.
- [x] New `test_skip_revert_period_is_not_called_when_disabled` asserts no skip-revert call is made when the config is `false`.

> ℹ️ Running the tests locally requires `guzzlehttp/guzzle` (Laravel's `Http::fake()` depends on it). It is not currently declared in `composer.json`'s `require-dev`; the existing test in `master` is affected by the same. Happy to add it as part of this PR if you'd like — I left it out to keep the diff focused on the behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy-request finalization by defaulting to calling PlanetScale’s `skip-revert` endpoint, which can affect rollback expectations and requires additional API permissions; failures could leave subsequent deploys blocked.
> 
> **Overview**
> **Automatically finalizes PlanetScale deploy requests** by calling `POST /deploy-requests/{n}/skip-revert` when a deployment reaches `complete_pending_revert`, preventing back-to-back deploys from being blocked by the revert window.
> 
> Adds an opt-out `planetscale.skip_revert_period` / `PLANETSCALE_SKIP_REVERT_PERIOD` config (default `true`), updates docs/changelog to describe the new behavior and required `approve_deploy_request` token permission, and extends feature tests with fixtures to cover both enabled/disabled paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458e51701009c2ff9dd448d8edef11cb00ac886d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically finalizes PlanetScale deploys by skipping the revert window once a deploy reaches `complete_pending_revert`, preventing back-to-back deploys from being blocked. If the skip-revert call fails, the command now exits successfully and prints a warning.

- **New Features**
  - Call `POST /deploy-requests/{n}/skip-revert` via `skipRevertPeriod()` when `deployment_state` is `complete_pending_revert`.
  - New config `planetscale.skip_revert_period` (`PLANETSCALE_SKIP_REVERT_PERIOD`, default `true`).
  - Docs/tests updated; service token now needs `approve_deploy_request` permission.

- **Bug Fixes**
  - Skip-revert failures no longer fail `pscale:migrate`; we warn and exit 0.

<sup>Written for commit 2ca95cde5312608d449d4b25ccae59f745aaf44b. Summary will update on new commits. <a href="https://cubic.dev/pr/Zahard-LTD/laravel-planetscale/pull/3?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

